### PR TITLE
use patched MapProxy with fix for multithreaded Azure Blob Storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get -y update \
 
 RUN pip3 install Numpy PyYAML boto3 Pillow requests Shapely eventlet gunicorn uwsgi prometheus_client lxml azure-storage-blob
 # use the PDOK fork of MapProxy. This is MapProxy version 1.13.1 but patched with https://github.com/mapproxy/mapproxy/pull/608
-RUN pip3 install git+https://github.com/PDOK/mapproxy.git@pdok-1.13.2-patched-1
+RUN pip3 install git+https://github.com/PDOK/mapproxy.git@pdok-1.13.2-patched-2
 
 # when overwriting the CMD with a uwsgi command it's good practice to not run it as root
 RUN groupadd -g 1337 mapproxy \


### PR DESCRIPTION
# Omschrijving

use patched MapProxy with fix for multithreaded Azure Blob Storage

https://github.com/PDOK/mapproxy/tree/pdok-1.13.2-patched-2
https://github.com/mapproxy/mapproxy/pull/630

## Type verandering

- Bugfix

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)