### PR TITLE
Pin lxml dependency on 5.0.2 and move dependencies to requirements.tx…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get -y update \
                libjpeg-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install flup Numpy PyYAML boto3 Pillow requests Shapely eventlet gunicorn uwsgi prometheus_client lxml azure-storage-blob pyproj==2.2.0
+COPY requirements.txt requirements.txt
+RUN pip3 install --requirement requirements.txt
 # use the PDOK fork of MapProxy. This is MapProxy version 1.13.1 but patched with https://github.com/mapproxy/mapproxy/pull/608
 RUN pip3 install git+https://github.com/PDOK/mapproxy.git@pdok-1.13.2-patched-2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+flup
+Numpy
+PyYAML
+boto3
+Pillow
+requests
+Shapely
+eventlet
+gunicorn
+uwsgi
+prometheus_client
+lxml==5.0.2
+azure-storage-blob
+pyproj==2.2.0


### PR DESCRIPTION

# Description

Pin lxml dependency on 5.0.2 and move dependencies to requirements.txt to support local builds.

To fix: https://github.com/PDOK/mapproxy-docker/issues/19

## Type of change

- Minor change (typo, formatting, version bump)

# Checklist:

- [x] I've double-checked the code in this PR myself
- [x] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [x] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR