### PR TITLE
Upgrade MapProxy from patched 1.13.1 to stock 3.1.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ LABEL maintainer="PDOK dev <pdok@kadaster.nl>"
 
 USER root
 
+# wget is required for startup probe in mapproxy-operator
+# git is required for git cloning mapproxy in this Dockerfile
+# all other dependencies are required to build mapproxy
 RUN apt update && apt -y install --no-install-recommends \
   gcc \
   git \
+  wget \
   python3-pip \
   python3-dev \
   python3-pil \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 # wget is required for startup probe in mapproxy-operator
 # git is required for git cloning mapproxy in this Dockerfile
 # all other dependencies are required to build mapproxy
-RUN apt update && apt -y install --no-install-recommends \
+RUN apt-get update && apt-get -y install --no-install-recommends \
   gcc \
   git \
   wget \
@@ -25,11 +25,9 @@ COPY requirements.txt requirements.txt
 RUN pip install -v --break-system-packages --requirement requirements.txt
 RUN pip install -v --break-system-packages git+https://github.com/mapproxy/mapproxy.git@3.1.3
 
-RUN apt-get clean
-
 # default dir needed for the cache_data
-RUN mkdir -p /srv/mapproxy/cache_data
-RUN chmod a+rwx /srv/mapproxy/cache_data
+RUN mkdir -p /srv/mapproxy/cache_data && \
+    chmod a+rwx /srv/mapproxy/cache_data
 
 WORKDIR /srv/mapproxy
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
-FROM pdok/lighttpd:1.4.67
+FROM pdok/lighttpd:1.4.67-bookworm
 LABEL maintainer="PDOK dev <pdok@kadaster.nl>"
 
 USER root
 
-# apt-get python3-pip on debian:buster will install python3.7
-RUN apt-get -y update \
-    && apt-get install -y \
-               python3-pip \
-               libpcre3 \
-               libpcre3-dev \
-               libproj13 \
-               libgeos-dev \
-               libgdal20 \
-               git \
-               wget \
-               zlib1g-dev \
-               libjpeg-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt -y install --no-install-recommends \
+  gcc \
+  git \
+  python3-pip \
+  python3-dev \
+  python3-pil \
+  libgeos-dev \
+  libgdal-dev \
+  libxml2-dev \
+  libxslt-dev && \
+  apt-get -y --purge autoremove && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt requirements.txt
-RUN pip3 install --requirement requirements.txt
-# use the PDOK fork of MapProxy. This is MapProxy version 1.13.1 but patched with https://github.com/mapproxy/mapproxy/pull/608
-RUN pip3 install git+https://github.com/PDOK/mapproxy.git@pdok-1.13.2-patched-2
+RUN pip install -v --break-system-packages --requirement requirements.txt
+RUN pip install -v --break-system-packages git+https://github.com/mapproxy/mapproxy.git@3.1.3
 
 RUN apt-get clean
 
@@ -40,11 +38,11 @@ RUN chmod +x start.py
 
 USER www
 
-ENV DEBUG 0
-ENV MIN_PROCS 4
-ENV MAX_PROCS 8
-ENV MAX_LOAD_PER_PROC 1
-ENV IDLE_TIMEOUT 20
+ENV DEBUG=0
+ENV MIN_PROCS=4
+ENV MAX_PROCS=8
+ENV MAX_LOAD_PER_PROC=1
+ENV IDLE_TIMEOUT=20
 
 EXPOSE 80
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ eventlet
 gunicorn
 uwsgi
 prometheus_client
-lxml==5.0.2
+lxml>=5.0.2
 azure-storage-blob
-pyproj==2.2.0
+pyproj>=2.2.0


### PR DESCRIPTION
# Description

Upgrade MapProxy from patched 1.13.1 to stock 3.1.3. Also includes upgrades of all Python dependencies, GDAL, GEOS, PROJ, etc. And upgrade from Debian Buster to Debian Bookworm.

## Type of change

(Remove irrelevant options)

- Upgrade

# Checklist:

- [ ] I've double-checked the code in this PR myself
- [ ] I've left the code better than before ([boy scout rule](https://wiki.c2.com/?BoyScoutRule))
- [ ] The code is readable, comments are added that explain hard or non-obvious parts.
- [ ] I've expanded/improved the (unit) tests, when applicable
- [ ] I've run (unit) tests that prove my solution works
- [ ] There's no sensitive information like credentials in my PR